### PR TITLE
Add generic event factory

### DIFF
--- a/assembly/defaults.ts
+++ b/assembly/defaults.ts
@@ -6,6 +6,24 @@ let defaultBigInt = BigInt.fromI32(1);
 let defaultIntBytes = Bytes.fromI32(1);
 let defaultEventDataLogType = "default_log_type";
 
+export function newEvent<EventType>(values: Array<ethereum.Value>): EventType {
+    let params = values.map<ethereum.EventParam>(
+        (value) => new ethereum.EventParam("parameter", value)
+    );
+
+    let event = new ethereum.Event(
+        defaultAddress,
+        defaultBigInt,
+        defaultBigInt,
+        defaultEventDataLogType,
+        newBlock(),
+        newTransaction(),
+        params,
+        newTransactionReceipt()
+    );
+    return changetype<EventType>(event);
+}
+
 export function newMockEvent(): ethereum.Event {
     return new ethereum.Event(defaultAddress, defaultBigInt,
         defaultBigInt, defaultEventDataLogType, newBlock(), newTransaction(), [], newTransactionReceipt());


### PR DESCRIPTION
With this function, most of the boilerplate code through createFooEvent helpers can be avoided. It can be called with an array of ethereum.Value directly.

Here is an example:

```
        // You can define values as a variable:
        let signature = Bytes.fromHexString(
            "0x2233cc"
        ); 

        // Or parse them directly:
        let newFooEvent = newEvent<FooEvent>([
            ethereum.Value.fromAddress(
                Address.fromString("0xa16081f360e3847006db660bae1c6d1b2e17ec2a")
            ),
            ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
            ethereum.Value.fromBytes(signature),
        ]);

        // Now you simply handle the new event
        handleFooEvent(newFooEvent);
```